### PR TITLE
Button to the ADEQUATe landing page of the dataset

### DIFF
--- a/ckanext/odpat/templates/package/snippets/info.html
+++ b/ckanext/odpat/templates/package/snippets/info.html
@@ -5,7 +5,7 @@
    <div class="adequate_badge">
      <dl>
        <dd>
-         <a href="http://opendataportal.pages.adequate.at:8082/{{pkg.name}}/" target="_blank">
+         <a href="http://opendataportal.pages.adequate.at/{{pkg.name}}/" target="_blank">
            <img src="http://badge.adequate.at/adequate/portalwatch/www_opendataportal_at/{{pkg.id}}" alt="" onerror="this.style.display='none';" />
          </a>
        </dd>

--- a/ckanext/odpat/templates/package/snippets/info.html
+++ b/ckanext/odpat/templates/package/snippets/info.html
@@ -5,7 +5,7 @@
    <div class="adequate_badge">
      <dl>
        <dd>
-         <a href="http://www_opendataportal_at.pages.adequate-project.semantic-web.at:8082/{{pkg.name}}/" target="_blank">
+         <a href="http://opendataportal.pages.adequate.at:8082/{{pkg.name}}/" target="_blank">
            <img src="http://badge.adequate.at/adequate/portalwatch/www_opendataportal_at/{{pkg.id}}" alt="" onerror="this.style.display='none';" />
          </a>
        </dd>

--- a/ckanext/odpat/templates/package/snippets/info.html
+++ b/ckanext/odpat/templates/package/snippets/info.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block heading %}
+   <h1 class="heading">{{ pkg.title or pkg.name }}</h1>
+   <div class="adequate_badge">
+     <dl>
+       <dd>
+         <a href="http://www_opendataportal_at.pages.adequate-project.semantic-web.at:8082/{{pkg.name}}/" target="_blank">
+           <img src="http://badge.adequate.at/adequate/portalwatch/www_opendataportal_at/{{pkg.id}}" alt="" onerror="this.style.display='none';" />
+         </a>
+       </dd>
+     <dl>
+   </div>
+{% endblock %}


### PR DESCRIPTION
This template displays a button on the CKAN dataset page if there is a ADEQUATe version available. 
See http://www.adequate.at/ for the ADEQUATe project